### PR TITLE
 Updating the modifiers of SafeMath.sol functions in compile.sol to pure

### DIFF
--- a/tutorial-11/Compiled.sol
+++ b/tutorial-11/Compiled.sol
@@ -53,25 +53,25 @@ contract Token {
 }
 
 library SafeMath {
-  function mul(uint256 a, uint256 b) internal constant returns (uint256) {
+  function mul(uint256 a, uint256 b) internal pure returns (uint256) {
     uint256 c = a * b;
     assert(a == 0 || c / a == b);
     return c;
   }
 
-  function div(uint256 a, uint256 b) internal constant returns (uint256) {
+  function div(uint256 a, uint256 b) internal pure returns (uint256) {
     // assert(b > 0); // Solidity automatically throws when dividing by 0
     uint256 c = a / b;
     // assert(a == b * c + a % b); // There is no case in which this doesn't hold
     return c;
   }
 
-  function sub(uint256 a, uint256 b) internal constant returns (uint256) {
+  function sub(uint256 a, uint256 b) internal pure returns (uint256) {
     assert(b <= a);
     return a - b;
   }
 
-  function add(uint256 a, uint256 b) internal constant returns (uint256) {
+  function add(uint256 a, uint256 b) internal pure returns (uint256) {
     uint256 c = a + b;
     assert(c >= a);
     return c;


### PR DESCRIPTION
Deploying Compile.sol with the latest Solidity will throw several warnings like this 
```
Function state mutability can be restricted to pure
```
one to let us know that the functions aren't just constant. Hence updating these modifiers to pure communicates the behaviour more precisely. But if someone compiles MyToken.sol using compiler like solc, it won't show such warnings as it has been fixed by zeppelin-solidity in their SafeMath.sol
  